### PR TITLE
patch: add test server

### DIFF
--- a/list.json
+++ b/list.json
@@ -713,6 +713,17 @@
           "online": true
         }
       ]
+    },
+    "ts01": {
+      "archived": false,
+      "testnet": true,
+      "list": [
+        {
+          "host": "test.peertube.pocketnet.app",
+          "upload": true,
+          "online": true
+        }
+      ]
     }
   }
 }

--- a/list.json
+++ b/list.json
@@ -1,5 +1,5 @@
 {
-  "lastChecked": 1703189815238,
+  "lastChecked": 1712154840783,
   "archive": {
     "ar01": {
       "host": "peertube.archive.pocketnet.app",
@@ -720,6 +720,7 @@
       "list": [
         {
           "host": "test.peertube.pocketnet.app",
+          "ip": "65.108.83.132",
           "upload": true,
           "online": true
         }


### PR DESCRIPTION
- New property for swarm - `testnet: true`. Allows to determine for which network this swarm is used.